### PR TITLE
properly exit handler on connection closed

### DIFF
--- a/sigma_tcp.c
+++ b/sigma_tcp.c
@@ -195,7 +195,9 @@ static void handle_connection(int fd)
 			case FSM_IDLE:
 				ret = read(fd, p, MAX_BUF_SIZE - count);
 				if (ret <= 0)
-					break;
+				{
+					goto free_handler;
+				}
 				else {
 					p += ret;
 					count += ret;
@@ -356,7 +358,7 @@ static void handle_connection(int fd)
 				break;
 		}
 	}
-
+free_handler:
 	free(buf);
 }
 


### PR DESCRIPTION
This fixes the event handler not yielding properly after a connection is closed.